### PR TITLE
Add a single step to run samtools stats on a set of BAM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo contains a collection of ad-hoc and flexible pipelines for running com
 See [Available Pipelines](#Available-pipelines) section for a list & description of available workflows. Well defined/flexible pipelines include:
 - [Salmon transcript quantification](#Salmon)
 - [Pull FASTQs from coordinate-sorted BAM files](#Pull-FASTQs-from-BAM-files)
+- [Generate summary statistics from BAM files with samtools stats](#Generate-summary-statistics-from-BAM-files-with-samtools-stats)
 
 # Running instructions
 
@@ -44,3 +45,14 @@ Snakefile: `single_steps/sort_pull.smk`
 Config file: `config/sort_pull_config.yaml`
 
 Cluster config file: `config/cluster/sort_pull.yaml`
+
+
+### Generate summary statistics from BAM files with samtools stats
+
+Runs samtools stats over a set of input BAM files. Also collapses the 'summary/SN section' into a single summary table for all samples (requires pandas to be installed outside of pipeline, which is usually satisfied by a snakemake installation). See [documentation](http://www.htslib.org/doc/samtools-stats.html) for a full breakdown/description of calculated metrics.
+
+Snakefile: `single_steps/samtools_stats.smk`
+
+Config file: `config/samtools_stats_config.yaml`
+
+Cluster config file: `config/cluster/samtools_stats.yaml`

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ Cluster config file: `config/cluster/sort_pull.yaml`
 
 ### Generate summary statistics from BAM files with samtools stats
 
-Runs samtools stats over a set of input BAM files. Also collapses the 'summary/SN section' into a single summary table for all samples (requires pandas to be installed outside of pipeline, which is usually satisfied by a snakemake installation). See [documentation](http://www.htslib.org/doc/samtools-stats.html) for a full breakdown/description of calculated metrics.
+Runs `samtools stats over a set of input BAM files`. Also collapses the 'summary/SN section' into a single summary table for all samples. See [documentation](http://www.htslib.org/doc/samtools-stats.html) for a full breakdown/description of calculated metrics.
 
 Snakefile: `single_steps/samtools_stats.smk`
 
 Config file: `config/samtools_stats_config.yaml`
 
 Cluster config file: `config/cluster/samtools_stats.yaml`
+
+Note: Requires pandas to be installed outside of pipeline, which is usually satisfied by a standard snakemake installation.

--- a/config/cluster/samtools_stats.yaml
+++ b/config/cluster/samtools_stats.yaml
@@ -1,0 +1,10 @@
+__default__:
+    h_vmem: 4G
+    h_rt:   1:0:0
+    submission_string: " "
+    tmem: 4G
+samtools_stats:
+    submission_string: "-pe smp 2 -R y"
+    h_vmem:   14G
+    tmem:   14G
+    h_rt: 24:00:00

--- a/config/samtools_stats_config.yaml
+++ b/config/samtools_stats_config.yaml
@@ -1,0 +1,20 @@
+# Directory containing input BAMs from which to extract FASTQs
+input_dir: tests/test_data/
+bam_suffix: ".bam"
+
+# Directory to store output of samtools stats
+output_dir: tests/test_data/
+
+# Name of tab-separated summary output table of the 'SN:' section of samtools stats output
+# file_name | metric | value
+summary_out_file: samtools_stats_sn_summary.tsv
+
+# Number of extra threads to use for samtools stats
+# Set to 0 if want to run single threaded and update config/cluster/samtools_stats.yaml if submitting to UCL CS cluster
+stats_extra_threads: 1
+
+# -p, --remove-overlaps : Remove overlaps of paired-end reads from coverage and base count computations.
+# True: Pass flag, False to not pass the flag (no quotes - has to be interpreted as a boolean)
+remove_pe_overlaps: True
+
+log_dir: samtools_stats_log/

--- a/scripts/combine_stats_sn_tables.py
+++ b/scripts/combine_stats_sn_tables.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import os
+import sys
+
+'''
+Quick and dirty script to combine extracted 'SN' sections of samtools stats output into a single file
+'''
+
+def main(in_dir, suffix, out_file):
+
+    # find file names that match suffix
+    samples2path = {f.replace(suffix, ""): os.path.join(in_dir, f)
+                    for f in os.listdir(in_dir) if f.endswith(suffix)
+                    }
+
+    print(samples2path)
+
+    assert len(samples2path) != 0, f"No files found in {in_dir} with suffix {out_file}"
+
+    # Read in TSVs into dataframes
+    dfs = {sample: pd.read_csv(path, sep="\t", header=None, names=["metric", "value", "comment"])
+           for sample, path in samples2path.items()}
+
+    # Concat into a single df, appending the sample name as a column
+    df = pd.concat(dfs.values(),
+                   keys=dfs.keys(),
+                   names=["sample_name", None]).reset_index("sample_name").reset_index(drop=True)
+
+    df.sort_values(by="sample_name", inplace=True)
+
+    df.to_csv(out_file, sep="\t", header=True, index=False, na_rep="NA")
+
+if __name__ == '__main__':
+
+    help = """python combine_stats_sn_tables.py INPUT_DIR FILE_SUFFIX OUT_FILE
+              INPUT_DIR - path to input directory containing 'SN' samtools stats sections to combine
+              FILE_SUFFIX - string suffix to identify files containing 'SN' samtools stats output for a given file
+              OUT_FILE - name of output table of combined SN outputs for all identified files
+             """
+
+    if len(sys.argv) == 1:
+        print(help)
+        sys.exit(0)
+
+    elif "-h" in sys.argv or "--help" in sys.argv:
+        print(help)
+        sys.exit(0)
+
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/scripts/combine_stats_sn_tables.py
+++ b/scripts/combine_stats_sn_tables.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
     help = """python combine_stats_sn_tables.py INPUT_DIR FILE_SUFFIX OUT_FILE
               INPUT_DIR - path to input directory containing 'SN' samtools stats sections to combine
-              FILE_SUFFIX - string suffix to identify files containing 'SN' samtools stats output for a given file
+              FILE_SUFFIX - string suffix to identify files containing 'SN' samtools stats output for a given file (i.e. output extracted with grep ^SN <samtools_stats.txt> | cut -f 2-)
               OUT_FILE - name of output table of combined SN outputs for all identified files
              """
 

--- a/single_steps/samtools_stats.smk
+++ b/single_steps/samtools_stats.smk
@@ -1,0 +1,64 @@
+configfile: "config/samtools_stats_config.yaml"
+
+import os
+import sys
+
+in_bam_dir = config["input_dir"]
+bam_suffix = config["bam_suffix"]
+out_dir = config["output_dir"]
+
+summary_out = os.path.join(out_dir, config["summary_out_file"])
+log_dir = os.path.join(out_dir, config["log_dir"])
+
+SAMPLES = [f.replace(bam_suffix, "") for f in os.listdir(in_bam_dir) if f.endswith(bam_suffix)]
+
+# Check that each input sample has a BAM index (.bai)
+for s in SAMPLES:
+    assert os.path.exists(os.path.join(in_bam_dir, s + bam_suffix + ".bai")), f".bai index file does not exist at same location as input BAM file for sample {s}"
+
+assert isinstance(config["remove_pe_overlaps"], bool), f"'remove_pe_overlaps' must be True/False boolean, {config['remove_pe_overlaps']} (type {type(config['remove_pe_overlaps'])}) was provided"
+
+
+sys.stderr.write(f"Basenames for input BAM files - {', '.join(SAMPLES)}\n")
+
+if not os.path.exists(out_dir):
+    os.system(f"mkdir -p {out_dir}")
+
+
+wildcard_constraints:
+    sample = "|".join(SAMPLES)
+
+
+rule all:
+    input:
+        # summary_out,
+        expand(os.path.join(out_dir, "{sample}.samtools_stats.txt"), sample=SAMPLES)
+
+
+rule samtools_stats:
+    input:
+        os.path.join(in_bam_dir, "{sample}" + bam_suffix)
+
+    output:
+        os.path.join(out_dir, "{sample}.samtools_stats.txt")
+
+    params:
+        extra_threads = config["stats_extra_threads"],
+        rm_overlaps = "--remove-overlaps" if config["remove_pe_overlaps"] else "",
+
+    threads:
+        config["stats_extra_threads"] + 1
+
+    log:
+        os.path.join(log_dir, "{sample}.samtools_stats.log")
+
+    conda:
+        "../envs/single_steps.yaml"
+
+    shell:
+        """
+        samtools stats \
+        --threads {params.extra_threads} \
+        {params.rm_overlaps} \
+        {input} > {output} 2> {log}
+        """

--- a/single_steps_submits/submit_samtools_stats.sh
+++ b/single_steps_submits/submit_samtools_stats.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#Submit to the cluster, give it a unique name
+#$ -S /bin/bash
+
+#$ -cwd
+#$ -V
+#$ -l h_vmem=1.9G,h_rt=20:00:00,tmem=1.9G
+#$ -pe smp 2
+
+# join stdout and stderr output
+#$ -j y
+#$ -R y
+
+if [ "$1" != "" ]; then
+    RUN_NAME=$1
+else
+    RUN_NAME=$""
+fi
+
+FOLDER=$(date +"%Y%m%d%H%M")
+WRITEFOLDER=../submissions/$FOLDER
+mkdir -p $WRITEFOLDER
+cp single_steps/samtools_stats.smk $WRITEFOLDER/samtools_stats.smk
+
+snakemake -s single_steps/samtools_stats.smk \
+--jobscript cluster_qsub.sh \
+--cluster-config config/cluster/samtools_stats.yaml \
+--cluster-sync "qsub -l tmem={cluster.tmem},h_vmem={cluster.h_vmem},h_rt={cluster.h_rt} -o $FOLDER {cluster.submission_string}" \
+-j 40 \
+--nolock \
+--rerun-incomplete \
+--latency-wait 100

--- a/single_steps_submits/submit_sort_pull.sh
+++ b/single_steps_submits/submit_sort_pull.sh
@@ -24,7 +24,7 @@ cp single_steps/sort_pull.smk $WRITEFOLDER/sort_pull.smk
 
 snakemake -s single_steps/sort_pull.smk \
 --jobscript cluster_qsub.sh \
---cluster-config config/cluster.yaml \
+--cluster-config config/cluster/sort_pull.yaml \
 --cluster-sync "qsub -l tmem={cluster.tmem},h_vmem={cluster.h_vmem},h_rt={cluster.h_rt} -o $FOLDER {cluster.submission_string}" \
 -j 40 \
 --nolock \


### PR DESCRIPTION
This PR adds a single step that runs `samtools stats` on a set of BAM files from a directory. As there is a lot of info output by this command, it also extracts the 'summary metrics' ('SN' section) from the output of each file and combines them into a single summary table.

Main reason I wanted to do this was to get read length and read depth robustly from BAM files, but extra info along the way could also be useful :)

I don't have any test data to add, but I'm working through running this on all the tdp depletion datasets. You can take my word (and photographic evidence) that Ferguson HeLas ran successfully on my end and others in progress are flying through the queue...
![image](https://user-images.githubusercontent.com/49978382/189701799-aa4e06b7-0ad0-46e5-9ad8-6444f4620bdc.png)

Let me know if you'd like any changes to be made/further clarification!