### PR TITLE
Add rule to run infer_experiment.py on a set of BAM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See [Available Pipelines](#Available-pipelines) section for a list & description
 - [Salmon transcript quantification](#Salmon)
 - [Pull FASTQs from coordinate-sorted BAM files](#Pull-FASTQs-from-BAM-files)
 - [Generate summary statistics from BAM files with samtools stats](#Generate-summary-statistics-from-BAM-files-with-samtools-stats)
+- [Infer strandedness of RNA-seq reads from BAM files with infer_experiment.py](#Infer-strandedness-of-an-RNA-seq-experiment-from-BAM-files-with-infer_experiment.py)
 
 # Running instructions
 
@@ -58,3 +59,18 @@ Config file: `config/samtools_stats_config.yaml`
 Cluster config file: `config/cluster/samtools_stats.yaml`
 
 Note: Requires pandas to be installed outside of pipeline, which is usually satisfied by a standard snakemake installation.
+
+
+### Infer strandedness of an RNA-seq experiment from BAM files with infer_experiment.py
+
+Runs RSeQC's `infer_experiment.py` over a set of input BAM files to infer the 'strandedness' of the input RNA reads. Also requires transcript annotation in BED12 format, which can be generated from a GTF file using the recipe in `single_steps/gtf_to_bed12.smk`.
+
+See [Documentation](https://rseqc.sourceforge.net/#infer-experiment-py) for interpretation of the output files. The following blog posts are also handy for translating the definition to the correct parameter for popular RNA-seq tools - [1](https://rnabio.org/module-09-appendix/0009/12/01/StrandSettings/), [2](https://littlebitofdata.com/en/2017/08/strandness_in_rnaseq/).
+
+Snakefile: `single_steps/infer_experiment.smk`
+
+Config file: `config/infer_experiment_config.yaml`
+
+Cluster config file: `config/cluster/infer_experiment.yaml`
+
+Command to submit to UCL cluster: `source submit.sh infer_experiment <optional_run_name>`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [Available Pipelines](#Available-pipelines) section for a list & description
 - [Salmon transcript quantification](#Salmon)
 - [Pull FASTQs from coordinate-sorted BAM files](#Pull-FASTQs-from-BAM-files)
 - [Generate summary statistics from BAM files with samtools stats](#Generate-summary-statistics-from-BAM-files-with-samtools-stats)
-- [Infer strandedness of RNA-seq reads from BAM files with infer_experiment.py](#Infer-strandedness-of-an-RNAseq-experiment-from-BAM-files-with-infer_experiment.py)
+- [Infer strandedness of RNA-seq reads from BAM files with infer_experiment.py](#Infer-strandedness-of-an-RNAseq-experiment-from-BAM-files-with-infer_experimentpy)
 
 # Running instructions
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [Available Pipelines](#Available-pipelines) section for a list & description
 - [Salmon transcript quantification](#Salmon)
 - [Pull FASTQs from coordinate-sorted BAM files](#Pull-FASTQs-from-BAM-files)
 - [Generate summary statistics from BAM files with samtools stats](#Generate-summary-statistics-from-BAM-files-with-samtools-stats)
-- [Infer strandedness of RNA-seq reads from BAM files with infer_experiment.py](#Infer-strandedness-of-an-RNA-seq-experiment-from-BAM-files-with-infer_experiment.py)
+- [Infer strandedness of RNA-seq reads from BAM files with infer_experiment.py](#Infer-strandedness-of-an-RNAseq-experiment-from-BAM-files-with-infer_experiment.py)
 
 # Running instructions
 
@@ -61,11 +61,11 @@ Cluster config file: `config/cluster/samtools_stats.yaml`
 Note: Requires pandas to be installed outside of pipeline, which is usually satisfied by a standard snakemake installation.
 
 
-### Infer strandedness of an RNA-seq experiment from BAM files with infer_experiment.py
+### Infer strandedness of an RNAseq experiment from BAM files with infer_experiment.py
 
 Runs RSeQC's `infer_experiment.py` over a set of input BAM files to infer the 'strandedness' of the input RNA reads. Also requires transcript annotation in BED12 format, which can be generated from a GTF file using the recipe in `single_steps/gtf_to_bed12.smk`.
 
-See [Documentation](https://rseqc.sourceforge.net/#infer-experiment-py) for interpretation of the output files. The following blog posts are also handy for translating the definition to the correct parameter for popular RNA-seq tools - [1](https://rnabio.org/module-09-appendix/0009/12/01/StrandSettings/), [2](https://littlebitofdata.com/en/2017/08/strandness_in_rnaseq/).
+See [documentation](https://rseqc.sourceforge.net/#infer-experiment-py) for interpretation of the output files. The following blog posts are also handy for translating the definition to the correct parameter for popular RNA-seq tools - [1](https://rnabio.org/module-09-appendix/0009/12/01/StrandSettings/), [2](https://littlebitofdata.com/en/2017/08/strandness_in_rnaseq/).
 
 Snakefile: `single_steps/infer_experiment.smk`
 

--- a/config/cluster/infer_experiment.yaml
+++ b/config/cluster/infer_experiment.yaml
@@ -1,0 +1,5 @@
+__default__:
+    h_vmem: 8G
+    h_rt:   24:00:00
+    submission_string: ""
+    tmem: 8G

--- a/config/infer_experiment_config.yaml
+++ b/config/infer_experiment_config.yaml
@@ -1,0 +1,17 @@
+# Directory containing input BAMs to infer_experiment
+input_dir: tests/test_data
+bam_suffix: ".bam"
+
+# Directory to store output of rseqc's infer_experiment.py
+output_dir: tests/test_data
+#
+bed12: tests/test_data/annotation.bed12
+
+# Number of reads to sample from BAM to infer strandedness
+sample_size: 200000
+
+# min map qual to be considered 'uniquely mapped'
+min_qual: 30
+
+# name of subdirectory under output_dir to store stderr outputs
+log_dir: infer_experiment_logs/

--- a/single_steps/infer_experiment.smk
+++ b/single_steps/infer_experiment.smk
@@ -1,0 +1,53 @@
+configfile: "config/infer_experiment_config.yaml"
+
+import os
+import sys
+
+in_bam_dir = config["input_dir"]
+bam_suffix = config["bam_suffix"]
+out_dir = config["output_dir"]
+log_dir = os.path.join(out_dir, config["log_dir"])
+
+SAMPLES = [f.replace(bam_suffix, "") for f in os.listdir(in_bam_dir) if f.endswith(bam_suffix)]
+
+# Check that each input sample has a BAM index (.bai)
+for s in SAMPLES:
+    assert os.path.exists(os.path.join(in_bam_dir, s + bam_suffix + ".bai")), f".bai index file does not exist at same location as input BAM file for sample {s}"
+
+
+wildcard_constraints:
+    sample = "|".join(SAMPLES)
+
+
+rule all:
+    input:
+        expand(os.path.join(out_dir, "{sample}.infer_experiment.txt"), sample=SAMPLES)
+
+
+rule infer_experiment:
+    input:
+        bam = os.path.join(in_bam_dir, "{sample}" + bam_suffix),
+        idx = os.path.join(in_bam_dir, "{sample}" + bam_suffix + ".bai")
+
+    output:
+        os.path.join(out_dir, "{sample}.infer_experiment.txt")
+
+    params:
+        annotation = config["bed12"],
+        sample_size = config["sample_size"], # Number of reads to sample from BAM
+        min_qual = config["min_qual"] # min map qual to be considered 'uniquely mapped'
+
+    conda:
+        "../envs/single_steps.yaml"
+
+    log:
+        os.path.join(log_dir, "{sample}.infer_experiment.log")
+
+    shell:
+        """
+        infer_experiment.py \
+        -i {input.bam} \
+        -r {params.annotation} \
+        -s {params.sample_size} \
+        -q {params.min_qual} > {output}
+        """

--- a/submit.sh
+++ b/submit.sh
@@ -15,7 +15,7 @@
 if [[ ( $@ == "--help") ||  $@ == "-h" ]]; then
     echo "Usage: source submit.sh SMK_NAME RUN_NAME"
     echo "SMK_NAME - Name of snakemake file (without .smk extension) under single_steps/ to run on cluster"
-    echo "RUN_NAME - Optional argument to name run. Config file for run will be copied to folder containing cluster log files (.submissions/<date><time>/) with run name prefixed"
+    echo "RUN_NAME - Optional argument to name run. Config file for run will be copied to folder containing cluster log files (submissions/<date><time>/) with run name prefixed"
     echo "-h/--help - print this help message and exit"
     exit 0
 fi


### PR DESCRIPTION
Had some BAM files provided by a collaborator where didn't have the strand information provided. This PR adds a quick Snakefile to run `infer_experiment.py` on a set of input BAM files. It is essentially a fancy shell script, but using this is much quicker than installing yourself, waiting for an interactive node or writing a job script to submit to the cluster.

Tested with Jack's new Illumina data and worked flawlessly (with low mem requirements it queues quite fast, so it finished w/in ~10-15 mins for ~15 BAMs!).